### PR TITLE
Permissions During Installation

### DIFF
--- a/documentation/installation/manual.md
+++ b/documentation/installation/manual.md
@@ -44,10 +44,18 @@ On Home Assistant (supervised/docker) the final location will be `/config/custom
 
 With a venv installation the final location will be `/home/homeassistant/.homeassistant/custom_components/hacs`.
 
-### Step 4 - Restart Home Assistant
+### Step 4 - Verify Permissions
+
+The user account running Home Assistant needs full control to the `custom_components` folder. Easiest way to do this is to have the user account that runs Home Assistant to own the `custom_components` folder.
+
+```
+sudo chown -R homeassistant:homeassistant custom_components/
+````
+
+### Step 5 - Restart Home Assistant
 
 Restart Home Assistant once before moving to the next step.
 
-### Step 5 - ✏️
+### Step 6 - ✏️
 
 You should now be done, next part will be to add it to your [configuration](configuration/start.md).

--- a/documentation/installation/manual.md
+++ b/documentation/installation/manual.md
@@ -54,8 +54,4 @@ sudo chown -R homeassistant:homeassistant custom_components/
 
 ### Step 5 - Restart Home Assistant
 
-Restart Home Assistant once before moving to the next step.
-
-### Step 6 - ✏️
-
-You should now be done, next part will be to add it to your [configuration](configuration/start.md).
+Restart Home Assistant once before moving on. After restarting, you will need to [add HACS to your configuration](configuration/start.md).

--- a/documentation/installation/manual.md
+++ b/documentation/installation/manual.md
@@ -30,30 +30,24 @@ With this content (**NB!: This was the content for 0.20.0, it may be different o
 
 **Do you see the `.translations` directory in the screenshot above? you _really really_ need that one.**
 
-### Step 3 - Move along the hacs folder to HA
+### Step 3 - Move the hacs folder to HA
 
 The folder named `hacs` needs to be copied to your Home Assistant installation.
 
-Use your favorite tool to move files to Home Assistant.
+Specifically, the `hacs` folder needs to be placed under `<config_dir>/custom_components/`.
 
-If this is your first custom_component you would need to create a new folder (see [step 4](#step-4---create-custom_components-folder)).
+If this is your first custom_component, that folder may not exist already. Go ahead and create it. The `custom_components` folder should exist in the same place as your `configuration.yaml` file.
 
-The `hacs` folder needs to be placed under `<config_dir>/custom_components/`
+Use your favorite tool to move the `hacs` folder to Home Assistant.
 
-On Home Assistant (supervised/docker) the final location will be `/config/custom_components/hacs`
+On Home Assistant (supervised/docker) the final location will be `/config/custom_components/hacs`.
 
-With a venv installation the final location will be `/home/homeassistant/.homeassistant/custom_components/hacs`
+With a venv installation the final location will be `/home/homeassistant/.homeassistant/custom_components/hacs`.
 
-### Step 4 - Create custom_components folder
-
-Open the folder where you have your `configuration.yaml` file.
-
-If you **do not** see a `custom_components` folder in **the same** folder as `configuration.yaml`, you need to create it.
-
-### Step 5 - Restart Home Assistant
+### Step 4 - Restart Home Assistant
 
 Restart Home Assistant once before moving to the next step.
 
-### Step 6 - ✏️
+### Step 5 - ✏️
 
 You should now be done, next part will be to add it to your [configuration](configuration/start.md).

--- a/documentation/installation/manual_cli.md
+++ b/documentation/installation/manual_cli.md
@@ -6,15 +6,65 @@ description: "Manual installation steps using the Linux command-line"
 
 This guide will help you install HACS using the Linux command-line on your Home Assistant server.
 
-### Step 1 - Run the install script
+# Method #1 - Installation Script
+
+### Step 1
+
+This command should be run as the user that runs Home Assistant.
+
+Don't blindly curl to bash! Take a look at [what the script does](https://hacs.xyz/install).
+
 ```
 curl -sfSL https://hacs.xyz/install | bash -
 ```
 
-### Step 2 - Restart Home Assistant
+### Step 2
 
 Restart Home Assistant once before moving to the next step.
 
-### Step 3 - ✏️
+### Step 3
 
 You should now be done. The next step is to add it to your [configuration](configuration/start.md).
+
+# Method #2 - Manual Commands
+
+The exact commands may vary.
+
+### Step 1
+
+Move the [latest HACS zip file](https://github.com/hacs/integration/releases/latest/download/hacs.zip) to your Home Assistant server.
+
+### Step 2
+
+Determine where the root of your Home Assistant configuration is located. This is the directory that contains your `configuration.yaml` file. (Example: `/home/homeassistant/.homeassistant/`)
+
+Move into that directory. (Or adjust your commands.)
+
+```
+cd /home/homeassistant/.homeassistant/
+````
+
+### Step 3
+
+The contents of the `hacs.zip` file need to be extracted to the `custom_components/hacs/` directory.
+
+If the `custom_components/` directory doesn't exist, create that first.
+
+```
+mkdir -p custom_components/hacs/
+unzip ~/hacs.zip -d custom_components/hacs/
+````
+
+### Step 4
+
+Make sure permissions are correct. The user that runs Home Assistant should be able to write to the `custom_components` directory, the `custom_components/hacs` directory, as well as the `www/` directory.
+
+```
+chown homeassistant:homeassistant custom_components/
+chown -R homeassistant:homeassistant custom_components/hacs/
+chown homeassistant:homeassistant www/
+````
+
+### Step 5
+
+Restart Home Assistant. After the restart, you should now be ready to add HACS to your [configuration](configuration/start.md).


### PR DESCRIPTION
This is my first PR, let me know if I made a mistake.

My primary goal is to ensure that the permissions on the files/directories that get created are correct.

The user account running Home Assistant needs to be able to write to the `custom_components` directory.

Many users have a dedicated account for running Home Assistant, and use another account to interact with the system. In this situation, if the installation is done as the normal (ie non-HA) account, the files/directories that are created will end up being owned by the user account that did the installation.

And in most cases, files/directories are only writable by their owner. The simplest solution (that I could think of) is to simply make sure all files are owned by the user account that runs Home Assistant.

I added a step that makes that change.

A second goal is to add _what_ steps are needed in the CLI installation directions. If this is listed, an advanced user can then perform the steps in their own environment. I gave example commands, but only as an example. The intent is to say _what needs to be happen_ and the user can decide out how to go about doing that.

A third goal is to make general readability improvements where possible. This is just merging steps or using different words, etc.

Hopefully, the change addresses #1089 in the [hacs/integration](https://github.com/hacs/integration) repo.