### PR TITLE
Add note about initial startup time to install doc

### DIFF
--- a/documentation/configuration/basic.md
+++ b/documentation/configuration/basic.md
@@ -43,6 +43,10 @@ If this takes longer than 10 minutes, you may have an issue with your Home Assis
 
 _If something failed, you will be taken back to the [Add your configuration step](#add-your-configuration)_
 
+:::info
+The initial startup can take up to 1 hour, for more details click [here](https://hacs.xyz/docs/faq/initial_startup)
+:::
+
 ## Changing the configuration
 
 If you need to change the configuration, you first need to delete the integration from the integrations list, then you need to add it back again.


### PR DESCRIPTION
Add a note that the first startup can take an hour so that a user does not have to got to the FAQ page to learn