### PR TITLE
Update start.md - make clear initial startup delay

### DIFF
--- a/documentation/configuration/start.md
+++ b/documentation/configuration/start.md
@@ -12,5 +12,5 @@ Before you start with the configuration, you will need to go to GitHub to get a 
 
 
 :::tip
-Read [this FAQ](/docs/faq/initial_startup) about the first startup of HACS.
+Read [this FAQ](/docs/faq/initial_startup) about the first startup of HACS. It may take over an hour to load all of the repositories on first startup.
 :::


### PR DESCRIPTION
It's quite easy to miss the "initial startup" tip, and from googling it seems that quite a few people are confused by an extended "HACS is starting up" message. May be able to clarify from the start page without having to click through?