### PR TITLE
Add ha-blueprint to tip part

### DIFF
--- a/documentation/publish/action.md
+++ b/documentation/publish/action.md
@@ -60,4 +60,5 @@ env:
 
 :::tip
 If you maintain an integration, you can also validate your integration with [hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest).
+For both plugins and cards, an easy way to automatically validate and format it would be with [ha-blueprint](https://github.com/KTibow/ha-blueprint).
 :::


### PR DESCRIPTION
I recently made a thing called ha-blueprint.
It runs validation on your repo, for both Python and JS. It runs hassfest and flake8 (if Python is detected), and ESLint (if JS is detected). And it also formats code with prettier (if JS is detected) and isort + black (if Python is detected).
I just wanted to add this, to get the word out about it.