### PR TITLE
Add cookiecutter-homeassistant-custom-component in documentation

### DIFF
--- a/documentation/publish/integration.md
+++ b/documentation/publish/integration.md
@@ -77,4 +77,4 @@ It is preferred but not required to publish releases in your repository.
 
 
 ### References and examples
-A good template to use as a reference is [blueprint](https://github.com/custom-components/blueprint).
+A good template to use as a reference is [blueprint](https://github.com/custom-components/blueprint). You can generate a template similar to blueprint and customized to your context by using [cookiecutter-homeassistant-custom-component](https://github.com/oncleben31/cookiecutter-homeassistant-custom-component).


### PR DESCRIPTION
As discussed with @ludeeus on Discord.

This cookiecutter template allows to generate a repository similar to blueprint but with customized names: 

- Integration name used in configuration UI.
- Project name on GitHub.
- Integration domain name
- Prefix to be use in classes name
- GitHub user name

