### PR TITLE
Extra instructions in Remove to help if HACS is installed again later

### DIFF
--- a/documentation/setup/remove.md
+++ b/documentation/setup/remove.md
@@ -12,6 +12,10 @@ If you want to remove HACS you need to do that using the following steps.
 1. Restart Home Assistant **important**
 1. Restart Home Assistant (yes, this needs to be done twice) **important**
 1. Delete the `hacs` directory under `custom_components`.
+1. Delete the following 3 files from the hidden `~/config/.storage` directory (this is only needed if you think you might install HACS again in future)
+   * `hacs.critical`
+   * `hacs.hacs`
+   * `hacs.repositories`
 1. Restart Home Assistant.
 
 When removed the wrong way. An option is to download it again.


### PR DESCRIPTION
When using HACS on Hassio, I've noticed that removing HACS leaves the `hacs.*` files still in the `.storage` directory.

These stale files seemed to cause an issue when I later re-installed HACS: It would still show the previous custom repositories in the HACS integrations page, even though they weren't actually present in the `custom_components` directory. Consequently it wasn't possible to either re-install those components, or to remove the repositories for re-adding them.

I discovered that the hacs.* files were stale and had timestamps from the earlier HACS installation, so gathered they hadn't been cleared down when the fresh HACS installation was done. They were out of sync.

(I'm guessing that the HACS install process doesn't overwrite existing hacs.* files - perhaps that would be a good fix, too.)

To fix the problem, I deleted the hacs.* files, re-installed HACS, and the repositories were in-sync again.

So I'm proposing a change here to the Remove instructions: encourage people to clear down those hacs.* files, to pave the way for easier re-installation in future.