### PR TITLE
Added instruction to make /hacsfiles folder available for docker users

### DIFF
--- a/documentation/setup/download.mdx
+++ b/documentation/setup/download.mdx
@@ -55,12 +55,22 @@ wget -O - https://get.hacs.xyz | bash -
 
 ```bash
 wget -O - https://get.hacs.xyz | bash -
-```
-
-
+```    
   </TabItem>
 </Tabs>
 
+
+### Missing /hacsfiles symlink 
+HACS frontend resource files are reffered to via the symlink /hacsfile (which should point to /config/www/community ). If this folder is not available on your docker image, consider adding it via an additional volume binding:
+
+```bash
+docker run
+  -v /volume1/docker/homeassistant:/config \
+  -v /volume1/docker/homeassistant/www/community:/hacsfiles \
+  homeassistant/home-assistant
+```
+
+Not doing so will result in frontend components not showing up in the UI.
 
   </TabItem>
   <TabItem value="core" label="Core">


### PR DESCRIPTION
After installing the official docker image for Home Assistant, and installing HACS via the documentation newly installed frontend components never showed up in to UI.

This was a severe pitfall for me as a new user. Took quite some time to figure out that on my official docker image this symlink / folder was never created.

Adding this to the documentation will hopefully save other new users some time.