### PR TITLE
dev: Fixing devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "HACS Documentation",
-	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:16",
+	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:18",
 	"context": "..",
 	"postStartCommand": "make init",
 	"settings": { 
@@ -9,14 +9,12 @@
 		"editor.formatOnSave": false,
 		"[javascript]": {
 		  "editor.defaultFormatter": "esbenp.prettier-vscode",
-		  "editor.formatOnSave": false,
-		  
-	}
+		  "editor.formatOnSave": false  
+		}
 	},
 	"appPort": ["3000:3000"],
 	"postCreateCommand": "make init",
 	"extensions": [
 		"dbaeumer.vscode-eslint"
 	]
-	}
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
 	"name": "HACS Documentation",
-	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14",
+	"image": "mcr.microsoft.com/vscode/devcontainers/javascript-node:16",
 	"context": "..",
 	"postStartCommand": "make init",
 	"settings": { 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ start: generate ## Start the documentation server
 	yarn start;
 
 bootstrap: ## Run yarn
-	apt update
-	apt install -y python3-pip
+	sudo apt update
+	sudo apt install -y python3-pip
 	rm -rf documentation/repositories
 	yarn global add prettier;
 	yarn;
@@ -23,3 +23,6 @@ generate: ## Build the documentation
 
 update: ## Pull main from hacs/documentation
 	git pull upstream main;
+
+upstream: ## Add upstream to be able to update
+    git remote add upstream https://github.com/hacs/documentation.git;

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,6 @@ start: generate ## Start the documentation server
 	yarn start;
 
 bootstrap: ## Run yarn
-	sudo apt update
-	sudo apt install -y python3-pip
 	rm -rf documentation/repositories
 	yarn global add prettier;
 	yarn;
@@ -23,6 +21,3 @@ generate: ## Build the documentation
 
 update: ## Pull main from hacs/documentation
 	git pull upstream main;
-
-upstream: ## Add upstream to be able to update
-    git remote add upstream https://github.com/hacs/documentation.git;


### PR DESCRIPTION
I fixed the dev container, it would not start because of version mismatch (docusaurus required node >=16) and the postStart command was doing an apt install which requires sudo in latest dev containers.