### PR TITLE
Minor edits for clarity, experimental URL

### DIFF
--- a/documentation/configuration/options.md
+++ b/documentation/configuration/options.md
@@ -5,10 +5,10 @@ description: "Configuration options"
 ---
 
 :::info
-_This page assumes that you have already finished the [initial configuration](/docs/configuration/basic)_
+_Finish [initial configuration](/docs/configuration/basic) before you modify HACS options described here._
 :::
 
-## In your Home Assistant UI go to the Integrations panel
+## In Home Assistant, go to the Settings ➤ Integrations panel
 
 [![Open your Home Assistant instance and show your integrations.](https://my.home-assistant.io/badges/integrations.svg)](https://my.home-assistant.io/redirect/integrations/)
 
@@ -20,17 +20,17 @@ _This page assumes that you have already finished the [initial configuration](/d
 
 ![image](/img/option3.png)
 
-- `Side panel title`: The name/title you want to display for HACS in the sidebar.
+- `Side panel title`: The text (name or title) to display for HACS in the sidebar. Defaults to "HACS".
 - `Side panel icon`: The icon you want to display for HACS in the sidebar.
 - `Number of releases to show`: Number of releases to show in the dropdown.
 - `Filter with country code`: Only show repositories for your country (if the repository has information about that)
 - `Enable AppDaemon apps discovery & tracking`: Enables [AppDaemon](/docs/categories/appdaemon_apps)
 - `Enable NetDaemon apps discovery & tracking`: Enables [NetDaemon](/docs/categories/netdaemon_apps)
     - NetDaemin apps is deprecated and will [deprecated](/docs/categories/netdaemon_apps#deprecation-notice) and will be removed from HACS.
-- `Enable experimental features`: This enables experimental features in HACS.
+- `Enable experimental features`: This enables [experimental features](https://experimental.hacs.xyz/) in HACS.
 
 :::note
-When changing the toggle for experimental features, you need to restart Home Assistant and clear the browser cache when it has fully started for it to properly be changed.
+After you change the setting for experimental features, you must fully reload HACS. Restart Home Assistant and then, once Home Assistant has fully started, clear your browser cache.
 :::
 
 ## Click submit and wait for confirmation


### PR DESCRIPTION
Adding a link to the experimental HACS site, plus some minor edits for clarity.

(Motivated by my own and [others'](https://discord.com/channels/606225571898327139/606225572485398550/1098262774062268528) confusion about the changed HACS primary user interface when in Experimental mode.)