### PR TITLE
Update download.mdx with an error fix I encountered

### DIFF
--- a/documentation/setup/download.mdx
+++ b/documentation/setup/download.mdx
@@ -89,3 +89,6 @@ wget -O - https://get.hacs.xyz | bash -
 
 - Having issues accessing `https://get.hacs.xyz` in the terminal?
   - Try it with `https://raw.githubusercontent.com/hacs/get/main/get` instead
+
+- Getting `ERROR: 'unzip' is not installed`?
+  - Try `sudo apt install unzip`  


### PR DESCRIPTION
Latest ubuntu server LTS (22.04) doesn't have "unzip" command by default