### PR TITLE
Add note to download about restart

### DIFF
--- a/documentation/setup/download.mdx
+++ b/documentation/setup/download.mdx
@@ -25,6 +25,7 @@ If you are not sure what type of Home Assistant you are using or how to find tha
 ```bash
 wget -O - https://get.hacs.xyz | bash -
 ```
+After the script is completed, remember to restart Home Assistant.
 
   </TabItem>
   <TabItem value="container" label="Container">


### PR DESCRIPTION
Added a note to the download instructions to restart homeassistant. 
This info is shown in the console, but can easily be missed.