### PR TITLE
Fixes lookup order in plugins.md

### DIFF
--- a/documentation/publish/plugin.md
+++ b/documentation/publish/plugin.md
@@ -23,10 +23,10 @@ Repository name: "lovelace-awesome-card"
 File name of one of the files: "awesome-card.js"
 ```
 
-When searching for accepted files HACS will look in this order:
+When searching for accepted files HACS will look in this order (based on value of `content_in_root` in hacs.json):
 
-- The `dist`directory.
-- On the latest release.
+- On the latest release if `content_in_root` is `false`.
+- The `dist` directory if `content_in_root` is `false`.
 - The root of the repository.
 
 All `.js` files it finds in the first location it finds one that matches the name will be downloaded.


### PR DESCRIPTION
I got this error: "<Plugin Tomdein/homeassistant-public-transport-idos-card> Repository structure for main is not compliant", so I was digging in the code, and I found that the look-up order of plugin files in docs does not match the code in function `update_filenames()` in `hacs/repositories/plugin.py`.

The look-up order skips `repository` and `dist` if `content_in_root` is true in hacs.json.

P.S.:
I tested the look-up order, and I got the "Repository structure for main is not compliant" error if `content_in_root` is `true` and I place the file in `dist` folder.