### PR TITLE
Fix typos in options.md

### DIFF
--- a/documentation/configuration/options.md
+++ b/documentation/configuration/options.md
@@ -24,7 +24,7 @@ _Finish [initial configuration](/docs/configuration/basic) before you modify HAC
 - `Filter with country code`: Only show repositories for your country (if the repository has information about that).
 - `Enable AppDaemon apps discovery & tracking`: Enables [AppDaemon](/docs/categories/appdaemon_apps).
 - `Enable NetDaemon apps discovery & tracking`: Enables [NetDaemon](/docs/categories/netdaemon_apps).
-  - NetDaemon apps is deprecated and will [deprecated](/docs/categories/netdaemon_apps#deprecation-notice) and will be removed from HACS.
+  - NetDaemon apps is [deprecated](/docs/categories/netdaemon_apps#deprecation-notice) and will be removed from HACS.
 - `Enable experimental features`: This enables [experimental features](https://experimental.hacs.xyz/) in HACS.
 
 :::note


### PR DESCRIPTION
fixed a line of text that was repeated in the "Configuration options" documentation