### PR TITLE
Correct __init__ filename in publish instructions

### DIFF
--- a/source/docs/publish/integration.md
+++ b/source/docs/publish/integration.md
@@ -17,7 +17,7 @@ For an integration repository to be valid, it must meet the requirements below.
 #### OK example:
 
 ```
-custom_components/awesome/__init_.py
+custom_components/awesome/__init__.py
 custom_components/awesome/sensor.py
 custom_components/awesome/manifest.json
 README.md
@@ -26,7 +26,7 @@ README.md
 #### Not OK example (1):
 
 ```
-awesome/__init_.py
+awesome/__init__.py
 awesome/sensor.py
 awesome/manifest.json
 README.md
@@ -35,7 +35,7 @@ README.md
 #### Not OK example (2):
 
 ```
-__init_.py
+__init__.py
 sensor.py
 manifest.json
 README.md

--- a/source/docs/publish/integration.md
+++ b/source/docs/publish/integration.md
@@ -21,6 +21,7 @@ custom_components/awesome/__init__.py
 custom_components/awesome/sensor.py
 custom_components/awesome/manifest.json
 README.md
+hacs.json
 ```
 
 #### Not OK example (1):
@@ -29,6 +30,7 @@ README.md
 awesome/__init__.py
 awesome/sensor.py
 awesome/manifest.json
+awesome/hacs.json
 README.md
 ```
 
@@ -39,6 +41,7 @@ __init__.py
 sensor.py
 manifest.json
 README.md
+hacs.json
 ```
 
 _if you have `content_in_root` set to `true` in [`hacs.json`](start.md#hacsjson) this is valid._


### PR DESCRIPTION
Fixed the filename for python's __init__.

I'm not sure if the single underscore was originally to stop markdown from underlining or something, but I think in the code quote block it should be ok?