### PR TITLE
Remove email in the footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ extra:
     - link: https://github.com/hacs/.github/blob/master/CODE_OF_CONDUCT.md
       title: Code of Conduct
       icon: fontawesome/solid/scale-balanced
-    - link: mailto:hi@hacs.xyz
+    - link: hi@hacs.xyz
       title: Contact (no support!)
       icon: fontawesome/solid/at
     - link: https://squidfunk.github.io/mkdocs-material/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,9 +82,6 @@ extra:
     - link: https://github.com/hacs/.github/blob/master/CODE_OF_CONDUCT.md
       title: Code of Conduct
       icon: fontawesome/solid/scale-balanced
-    - link: hi@hacs.xyz
-      title: Contact (no support!)
-      icon: fontawesome/solid/at
     - link: https://squidfunk.github.io/mkdocs-material/
       title: Made with Material for MkDocs
       icon: logo


### PR DESCRIPTION
`mailto` is great, however it doesn't work for a lot of PC users, including myself. I propose either removing the `mailto`(in this PR) or building in logic into the footer based on device type to only show `mailto` for mobile.

 A halfway solution could be adding the email as part of the footer, that way link does not need to be clicked.