### PR TITLE
Fix spacing of resource items in footer

### DIFF
--- a/source/assets/stylesheets/extra.css
+++ b/source/assets/stylesheets/extra.css
@@ -125,6 +125,10 @@ a.generated-grid-link p:last-of-type {
     max-width: 320px;
 }
 
+.resource-item {
+    margin-bottom: .5em;
+}
+
 input,
 form,
 div,

--- a/source/overrides/partials/content.html
+++ b/source/overrides/partials/content.html
@@ -31,7 +31,7 @@
             <h4>Resources</h4>
 
             {% for link in config.extra.resources %}
-            <div>
+            <div class="resource-item">
                 <span class="twemoji">
                     {% include ".icons/" ~ link.icon ~ ".svg" %}
                 </span>


### PR DESCRIPTION
Can't test this until I get home, will update then.

Follow up of #605, just fixes spacing to match list items on other side of footer.