### PR TITLE
Extend GitHub action documentation

### DIFF
--- a/source/docs/publish/action.md
+++ b/source/docs/publish/action.md
@@ -40,7 +40,7 @@ All these checks can be disabled with `with.ignore`. Use a string, and if you ig
 | `issues`      | [More info](/docs/publish/include.md#check-repository)    | Checks that issues are enabled                   |
 | `topics`      | [More info](/docs/publish/include.md#check-repository)    | Checks that the repository has topics            |
 
-## Using a Specific Version
+## Using a specific version
 
 To use a specific version of this action instead of `main` set the value after `@` in the `uses` definition, like:
 

--- a/source/docs/publish/action.md
+++ b/source/docs/publish/action.md
@@ -18,6 +18,38 @@ The action has 3 run types:
 
 The action itself lives [here](https://github.com/hacs/action) and you are free to inspect the code and/or make a PR to add changes.
 
+## Action inputs
+
+| Input      | Description                                                                             |
+| ---------- | --------------------------------------------------------------------------------------- |
+| `ignore`   | A space separated list of ignored checks                                                |
+| `category` | The type of repository (integration, plugin, template, theme, appdaemon, python_script) |
+
+## Ignorable checks
+
+All these checks can be disabled with `with.ignore`. Use a string, and if you ignore multiple ones, separate them with spaces.
+
+| Check         | More info                                                 | Description                                      |
+| ------------- | --------------------------------------------------------- | ------------------------------------------------ |
+| `archived`    | [More info](/docs/publish/include.md#check-archived)      | Checks if the repository is archived             |
+| `brands`      | [More info](/docs/publish/include.md#check-brands)        | Checks if the domain is added to the brands repo |
+| `description` | [More info](/docs/publish/include.md#check-repository)    | Checks if the repository has a description       |
+| `hacsjson`    | [More info](/docs/publish/include.md#check-hacs-manifest) | Checks that hacs.json exists                     |
+| `images`      | [More info](/docs/publish/include.md#check-images)        | Checks that the info file has images             |
+| `information` | [More info](/docs/publish/include.md#check-repository)    | Checks that the repo has an information file     |
+| `issues`      | [More info](/docs/publish/include.md#check-repository)    | Checks that issues are enabled                   |
+| `topics`      | [More info](/docs/publish/include.md#check-repository)    | Checks that the repository has topics            |
+
+## Using a Specific Version
+
+To use a specific version of this action instead of `main` set the value after `@` in the `uses` definition, like:
+
+```yaml
+uses: hacs/action@xx.xx.x
+```
+
+If you do this, please enable [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates) to help you keep that up to date.
+
 To use it, follow these steps:
 
 1. Go to your repository on GitHub
@@ -30,11 +62,13 @@ To use it, follow these steps:
 name: Validate
 
 on:
-  push: 
+  push:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
   workflow_dispatch:
+
+permissions: {}
 
 jobs:
   validate-hacs:
@@ -49,4 +83,4 @@ jobs:
 This will run on every PR and push and at midnight every day. And `workflow_dispatch` allows you to run the action on demand from the Actions tab.
 
 !!! tip
-    If you maintain an integration, you can also validate your integration with [hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest).
+If you maintain an integration, you can also validate your integration with [hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest).

--- a/source/docs/publish/action.md
+++ b/source/docs/publish/action.md
@@ -20,10 +20,10 @@ The action itself lives [here](https://github.com/hacs/action) and you are free 
 
 ## Action inputs
 
-| Input      | Description                                                                             |
-| ---------- | --------------------------------------------------------------------------------------- |
-| `ignore`   | A space separated list of ignored checks                                                |
-| `category` | The type of repository (integration, plugin, template, theme, appdaemon, python_script) |
+| Input      | Description                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------- |
+| `ignore`   | A space separated list of ignored checks                                                            |
+| `category` | The type of repository (`integration`, `plugin`, `template`, `theme`, `appdaemon`, `python_script`) |
 
 ## Ignorable checks
 

--- a/source/docs/publish/action.md
+++ b/source/docs/publish/action.md
@@ -83,4 +83,4 @@ jobs:
 This will run on every PR and push and at midnight every day. And `workflow_dispatch` allows you to run the action on demand from the Actions tab.
 
 !!! tip
-If you maintain an integration, you can also validate your integration with [hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest).
+    If you maintain an integration, you can also validate your integration with [hassfest](https://developers.home-assistant.io/blog/2020/04/16/hassfest).


### PR DESCRIPTION
Moves the information from https://github.com/hacs/action/blob/main/README.md for consolidation.