### PR TITLE
Change instructions from using "my" link to manually add the repository

### DIFF
--- a/source/docs/use/download/download.md
+++ b/source/docs/use/download/download.md
@@ -14,13 +14,12 @@ How you download HACS depends on your Home Assistant installation type. In the i
 
 === "OS/Supervised"
 
-    For Home Assistant Operating System and Supervised, there is an app for downloading HACS. To add the custom add-on repository that allows you to get this app, follow these steps.
+    For Home Assistant Operating System and Supervised, there is an app for downloading HACS. To add the custom app repository that allows you to get this app, follow these steps.
 
-    1. To add the HACS add-on repository to your Home Assistant, select this [my link](https://my.home-assistant.io/redirect/supervisor_addon/?addon=cb646a50_get&repository_url=https%3A%2F%2Fgithub.com%2Fhacs%2Faddons).
-        - When prompted to confirm if you want to open the page in Home Assistant, check if the URL is correct. Then, select **Open link**.
-        - In the **Missing add-on repository** dialog, select **Add**.
-        - You have now added the repository that allows you to download HACS to Home Assistant.
-    2. In the **Get HACS** app, select **Install**.
+    1. Add the HACS app repository to your Home Assistant.
+        - Follow the [Installing a third-party app repository](https://www.home-assistant.io/common-tasks/os/#installing-a-third-party-app-repository) instructions on the Home Assistant documentation.
+        - Use `https://github.com/hacs/addons` as the repository URL.
+    2. Go to **Settings** > **Apps** > **Install app** and select **Get HACS**. Then select **Install**.
     3. **Start** the app.
     4. Navigate to the app logs and follow the instructions given there.
 

--- a/source/docs/use/download/download.md
+++ b/source/docs/use/download/download.md
@@ -17,7 +17,7 @@ How you download HACS depends on your Home Assistant installation type. In the i
     For Home Assistant Operating System and Supervised, there is an app for downloading HACS. To add the custom app repository that allows you to get this app, follow these steps.
 
     1. Add the HACS app repository to your Home Assistant.
-        - Follow the [Installing a third-party app repository](https://www.home-assistant.io/common-tasks/os/#installing-a-third-party-app-repository) instructions on the Home Assistant documentation.
+        - Follow the [Installing a third-party app repository](https://www.home-assistant.io/common-tasks/os/#installing-a-third-party-app-repository) instructions in the Home Assistant documentation.
         - Use `https://github.com/hacs/addons` as the repository URL.
     2. Go to **Settings** > **Apps** > **Install app** and select **Get HACS**. Then select **Install**.
     3. **Start** the app.


### PR DESCRIPTION
Because of https://github.com/home-assistant/frontend/issues/29455, users are getting stuck, this changes the instructions to the more manual approach.