### PR TITLE
Add core domain override check documentation

### DIFF
--- a/source/docs/publish/action.md
+++ b/source/docs/publish/action.md
@@ -29,16 +29,17 @@ The action itself lives [here](https://github.com/hacs/action) and you are free 
 
 All these checks can be disabled with `with.ignore`. Use a string, and if you ignore multiple ones, separate them with spaces.
 
-| Check         | More info                                                 | Description                                      |
-| ------------- | --------------------------------------------------------- | ------------------------------------------------ |
-| `archived`    | [More info](/docs/publish/include.md#check-archived)      | Checks if the repository is archived             |
-| `brands`      | [More info](/docs/publish/include.md#check-brands)        | Checks if there are brand assets available       |
-| `description` | [More info](/docs/publish/include.md#check-repository)    | Checks if the repository has a description       |
-| `hacsjson`    | [More info](/docs/publish/include.md#check-hacs-manifest) | Checks that hacs.json exists                     |
-| `images`      | [More info](/docs/publish/include.md#check-images)        | Checks that the info file has images             |
-| `information` | [More info](/docs/publish/include.md#check-repository)    | Checks that the repo has an information file     |
-| `issues`      | [More info](/docs/publish/include.md#check-repository)    | Checks that issues are enabled                   |
-| `topics`      | [More info](/docs/publish/include.md#check-repository)    | Checks that the repository has topics            |
+| Check                  | More info                                                        | Description                                                   |
+| ---------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------- |
+| `archived`             | [More info](/docs/publish/include.md#check-archived)             | Checks if the repository is archived                          |
+| `brands`               | [More info](/docs/publish/include.md#check-brands)               | Checks if there are brand assets available                    |
+| `core_domain_override` | [More info](/docs/publish/include.md#check-core-domain-override) | Checks if the integration overrides a core integration domain |
+| `description`          | [More info](/docs/publish/include.md#check-repository)           | Checks if the repository has a description                    |
+| `hacsjson`             | [More info](/docs/publish/include.md#check-hacs-manifest)        | Checks that hacs.json exists                                  |
+| `images`               | [More info](/docs/publish/include.md#check-images)               | Checks that the info file has images                          |
+| `information`          | [More info](/docs/publish/include.md#check-repository)           | Checks that the repo has an information file                  |
+| `issues`               | [More info](/docs/publish/include.md#check-repository)           | Checks that issues are enabled                                |
+| `topics`               | [More info](/docs/publish/include.md#check-repository)           | Checks that the repository has topics                         |
 
 ## Using a specific version
 

--- a/source/docs/publish/include.md
+++ b/source/docs/publish/include.md
@@ -59,6 +59,13 @@ _Applies only to integrations._
 Checks that your integration has a brand directory with at least an `icon.png` file.
 If it doesn’t, it falls back to checking the domain in the [home-assistant/brands](https://github.com/home-assistant/brands) repository. 
 
+### Check core domain override
+
+_Applies only to integrations._
+
+Checks that your integration does not use the same domain as an integration that is part of Home Assistant core.
+Custom integrations that override a core integration are not accepted as defaults, see [Who can submit?](#who-can-submit).
+
 ### Check manifest
 
 Checks that your integration's manifest is valid. [Learn more](integration.md#manifestjson) or see the [integration manifest documentation](https://developers.home-assistant.io/docs/creating_integration_manifest). Applies only to integrations.


### PR DESCRIPTION
## Summary
This PR adds documentation for a new validation check that prevents custom integrations from overriding domains that belong to Home Assistant core integrations.

## Changes
- Added `core_domain_override` check to the checks table in `action.md` with documentation link and description
- Added new "Check core domain override" section in `include.md` explaining:
  - The check applies only to integrations
  - It validates that custom integrations don't use the same domain as core Home Assistant integrations
  - References the "Who can submit?" section regarding acceptance criteria
- Updated table formatting in `action.md` to accommodate the new check entry with proper column alignment

## Details
The new check enforces a requirement that custom integrations cannot override core integration domains, which is part of the submission criteria for default inclusion in HACS. This documentation change makes users aware of this validation rule when using the HACS action.

For https://github.com/hacs/integration/pull/5442