### PR TITLE
Fix download link from "Initial configuration"

### DIFF
--- a/source/docs/use/configuration/basic.md
+++ b/source/docs/use/configuration/basic.md
@@ -12,7 +12,7 @@ Follow these steps to set up the HACS integration and authenticate it with GitHu
 
 This guide assumes that you have completed the following steps:
 
-   - [Downloaded HACS](/docs/use/download/prerequisites.md)
+   - [Downloaded HACS](/docs/use/download/download/)
    - Restarted Home Assistant
 
 ### To set up the HACS integration


### PR DESCRIPTION
On the "Initial configuration" page, the link to **Downloaded HACS** links to the prerequisites page instead of the download page. This fixes it.